### PR TITLE
Relax guard for deploy trigger

### DIFF
--- a/.github/workflows/generate_site_and_deploy.yaml
+++ b/.github/workflows/generate_site_and_deploy.yaml
@@ -93,7 +93,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.event.sender.login == 'pankona' && github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
https://github.com/pankona/pankona.github.io/pull/229 で部分的に残したガードを取っ払いたい

なぜなら自分がマージするとデプロイされないので気軽にマージできないからです！ ref: https://github.com/pankona/pankona.github.io/pull/324#issuecomment-2466749574

そして本当に悪意がある場合は勝手にこれ削ったコミットpushすれば好き放題できるので、特に意味ある対策ではないなぁという気がした（このあたりGitHubでどう対策できるのかは知りたい。pagesはenvironment別れてるからenvironment毎にpermission分けるとかできるのかも・・・？）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
	- GitHub Actionsのデプロイワークフローを更新
	- デプロイメントの条件を変更し、特定のユーザーからの制限を解除
	- プルリクエスト以外のすべてのイベントでGitHub Pagesへのデプロイが可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->