### PR TITLE
Update flake with nixos-25.05 era

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
     in
     {
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
       devShells = forAllSystems (
         system:
         let


### PR DESCRIPTION
nixos-25.05 がリリースされたので、ざっくり更新しておきます。
現在は実際のデプロイ内容へ影響しません。

```console
> ./print_dependencies.bash
+ nix --version
nix (Nix) 2.28.3
+ hugo version
hugo v0.147.3+extended+withdeploy linux/amd64 BuildDate=unknown VendorInfo=nixpkgs
+ sass --version
1.89.0
+ go version
go version go1.24.3 linux/amd64
+ make --version
GNU Make 4.4.1
このプログラムは x86_64-pc-linux-gnu 用にビルドされました
Copyright (C) 1988-2023 Free Software Foundation, Inc.
ライセンス GPLv3+: GNU GPL バージョン 3 以降 <https://gnu.org/licenses/gpl.html>
これはフリーソフトウェアです: 自由に変更および配布できます.
法律の許す限り、　無保証　です.
+ dprint --version
dprint 0.49.1
+ typos --version
typos-cli 1.32.0
+ convert --version
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

Version: ImageMagick 7.1.1-47 Q16-HDRI x86_64 c8f4e8cb7:20250329 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fftw fontconfig freetype heic jng jp2 jpeg jxl lcms lqr lzma openexr pangocairo png raqm raw rsvg tiff webp x xml zlib zstd
Compiler: gcc (14.2)
+ actionlint --version
1.7.7
installed by building from source
built with go1.24.3 compiler for linux/amd64
+ ls --version
ls (GNU coreutils) 9.7
Packaged by https://nixos.org
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
+ nixfmt --version
nixfmt nixpkgs-unstable-2025-04-04
+ nixd --version
nixd, version: 2.6.4
+ peco --version
peco version v0.5.11 (built with go1.24.3)
+ vim --version
+ sed -n 1p
VIM - Vi IMproved 9.1 (2024 Jan 02, compiled Jan 01 1980 00:00:00)
+ markdownlint-cli2 --version
+ grep 'markdownlint v'
markdownlint-cli2 v0.17.2 (markdownlint v0.37.4)
```